### PR TITLE
Add new keyboard shortcuts for locking or unlocking the current tab.

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -154,6 +154,20 @@ const startup = function() {
         tabmanager.closedTabs.wrangleTabs(tabs);
       });
       break;
+    case 'lock-current-tab':
+      chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+        tabs.forEach(tab => {
+          tabmanager.lockTab(tab.id);
+        });
+      });
+      break;
+    case 'unlock-current-tab':
+      chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+        tabs.forEach(tab => {
+          tabmanager.unlockTab(tab.id);
+        });
+      });
+      break;
     default:
       break;
     }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -26,6 +26,20 @@
         "default": "Ctrl+Shift+E",
         "mac": "MacCtrl+Shift+W"
       }
+    },
+    "lock-current-tab": {
+      "description": "Lock the current tab",
+      "suggested-key": {
+        "default": "Ctrl+Shift+L",
+        "mac": "MacCtrl+Shift+L"
+      }
+    },
+    "unlock-current-tab": {
+      "description": "Unlock the current tab",
+      "suggested-key": {
+        "default": "Ctrl+Shift+U",
+        "mac": "MacCtrl+Shift+U"
+      }
     }
   },
   "minimum_chrome_version": "28",


### PR DESCRIPTION
I find myself locking tabs frequently, particularly when I'm looking at documentation or other reference material. This commit adds a couple keyboard shortcuts to make locking or unlocking the current tab a bit faster.