### PR TITLE
issue #130: Do not update last access time in 'onUpdated' event listener

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -150,7 +150,6 @@ const startup = function() {
   chrome.tabs.onCreated.addListener(onNewTab);
   chrome.tabs.onRemoved.addListener(tabmanager.removeTab);
   chrome.tabs.onReplaced.addListener(tabmanager.replaceTab);
-  chrome.tabs.onUpdated.addListener(tabmanager.updateLastAccessed);
   chrome.tabs.onActivated.addListener(function(tabInfo) {
     menus.updateContextMenus(tabInfo['tabId']);
 


### PR DESCRIPTION
When chrome is loaded it calls 'onUpdated' listener for each existing
tab with status:loading then with status:completed. This resets last
accessed time for all tabs when browser is restarted.

But we don't even need 'onUpdated' listener because we already have
'onActivated' and we also have regular (each 5 seconds) checks which
update last accessed time of current active tab.

Thus to fix issue #130 I just removed 'onUpdated' listener.