### PR TITLE
Adds a gulp target for building a signed firefox Addon

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-/*/ eslint-env node */
+/* eslint-env node */
 
 const archiver = require('archiver');
 const eslint = require('gulp-eslint');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-/* eslint-env node */
+/*/ eslint-env node */
 
 const archiver = require('archiver');
 const eslint = require('gulp-eslint');
@@ -16,6 +16,7 @@ const webpack = require('webpack');
 const packageJson = require('./package.json');
 const webpackConfig = require('./webpack.config.js');
 const webpackProductionConfig = require('./webpack.production.config.js');
+const webExt = require('web-ext/dist/web-ext').default;
 
 const DIST_DIRECTORY = 'dist';
 
@@ -177,6 +178,19 @@ gulp.task('archive', function(done) {
 
   // finalize the archive (ie we are done appending files but streams have to finish yet)
   archive.finalize();
+});
+
+// firefox extension signing: It needs a JWT_KEY and JWT_SECRET env variables set.
+// get those in https://addons.mozilla.org/en-US/developers/addon/api/key/
+gulp.task('firefox', ['release'], function(done) {
+  webExt.cmd.sign({
+    apiKey: process.env.JWT_KEY,
+    apiSecret: process.env.JWT_SECRET,
+    artifactsDir: '',
+    sourceDir: 'dist',
+  })
+    .then(() => done())
+    .catch(error => console.error('CAUGHT', error));
 });
 
 gulp.task('release', function(done) {

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "react-sticky": "^6.0.2",
     "react-virtualized": "^9.18.5",
     "timeago-react": "^2.0.0",
-    "timeago.js": "^3.0.2",
-    "web-ext": "^2.6.0"
+    "timeago.js": "^3.0.2"
   },
   "jest": {
     "globals": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "rimraf": "^2.6.2",
     "run-sequence": "^2.2.0",
     "style-loader": "^0.20.2",
-    "webpack": "^3.11.0"
+    "webpack": "^3.11.0",
+    "web-ext": "^2.6.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -62,7 +63,8 @@
     "react-sticky": "^6.0.2",
     "react-virtualized": "^9.18.5",
     "timeago-react": "^2.0.0",
-    "timeago.js": "^3.0.2"
+    "timeago.js": "^3.0.2",
+    "web-ext": "^2.6.0"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
Hi, thank you for the awesome extension.

I added a task to gulpfile to create a signed firefox package. You just need to create a set of credentials in addons.mozilla.org and then set the JWT_KEY and JWT_PASSWORD variables, then run 

`npm install` #to install web-ext
`gulp firefox` #to generate a signed xpi. 

You could maybe add the signed xpi in the releases, or maybe in mozilla addon store. 