### PR TITLE
Recover lost data

### DIFF
--- a/app/js/tabmanager.js
+++ b/app/js/tabmanager.js
@@ -135,13 +135,6 @@ const TabManager = {
   },
 
   filters: {
-    // Matches when the URL is exactly matching
-    exactUrl(url: string) {
-      return function(tab: chrome$Tab) {
-        return tab.url === url;
-      };
-    },
-
     // Matches either the title or URL containing "keyword"
     keyword(keyword: string) {
       return function(tab: chrome$Tab) {


### PR DESCRIPTION
Re-migrate/merge data from old pre-V6 location

If data still exists in the old pre-V6 location, this new migration will
merge the data into the new location and delete it from its previous
home.

Tested by doing the following:

1. Installed v5.12.2
2. Imported old data
3. Upgraded to v6.0.0, let it do the migration
4. Re-installed v5.12.2
5. Imported old data (now data in old location and in new location)
6. Upgraded to v6.0.0#recover-lost-data (this branch)
7. Ensured data in old location was merged into new location

Fixes #241