### PR TITLE
Remove "Chrome" from description

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -178,8 +178,8 @@
     "message": "URL"
   },
   "options_option_clearOnQuit_label": {
-    "description": "Label for checkbox to clear the tab list after quitting Chrome",
-    "message": "Liste der geschlossenen Tabs beim beenden von Chrome löschen"
+    "description": "Label for checkbox to clear the tab list after quitting the Browser",
+    "message": "Liste der geschlossenen Tabs beim beenden des Browsers löschen"
   },
   "options_option_debounceOnActivated_label": {
     "description": "Label for checkbox to reset a tab's timer only after it's active for 1 second",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -198,7 +198,7 @@
     "message": "URL String"
   },
   "options_option_clearOnQuit_label": {
-    "description": "Label for checkbox to clear the tab list after quitting Chrome",
+    "description": "Label for checkbox to clear the tab list after quitting the Browser",
     "message": "Clear closed tabs list on quit"
   },
   "options_option_debounceOnActivated_label": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -198,7 +198,7 @@
     "message": "Cadena URL"
   },
   "options_option_clearOnQuit_label": {
-    "description": "Label for checkbox to clear the tab list after quitting Chrome",
+    "description": "Label for checkbox to clear the tab list after quitting the Browser",
     "message": "Eliminar pestañas cerradas al salir"
   },
   "options_option_debounceOnActivated_label": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -198,7 +198,7 @@
     "message": "Texte d'URL"
   },
   "options_option_clearOnQuit_label": {
-    "description": "Label for checkbox to clear the tab list after quitting Chrome",
+    "description": "Label for checkbox to clear the tab list after quitting the Browser",
     "message": "Nettoyer la liste d'onglets fermés en quittant"
   },
   "options_option_debounceOnActivated_label": {

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -198,7 +198,7 @@
     "message": "URL 주소"
   },
   "options_option_clearOnQuit_label": {
-    "description": "Label for checkbox to clear the tab list after quitting Chrome",
+    "description": "Label for checkbox to clear the tab list after quitting the Browser",
     "message": "종료 시 닫힌 탭 목록 지우기"
   },
   "options_option_debounceOnActivated_label": {

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -198,7 +198,7 @@
     "message": "Добавленные адреса"
   },
   "options_option_clearOnQuit_label": {
-    "description": "Label for checkbox to clear the tab list after quitting Chrome",
+    "description": "Label for checkbox to clear the tab list after quitting the Browser",
     "message": "Очищать список закрытых вкладок при выходе"
   },
   "options_option_debounceOnActivated_label": {

--- a/_locales/zh-CN/messages.json
+++ b/_locales/zh-CN/messages.json
@@ -198,7 +198,7 @@
     "message": "URL 字符串"
   },
   "options_option_clearOnQuit_label": {
-    "description": "Label for checkbox to clear the tab list after quitting Chrome",
+    "description": "Label for checkbox to clear the tab list after quitting the Browser",
     "message": "退出时清除已关闭标签页的列表"
   },
   "options_option_debounceOnActivated_label": {


### PR DESCRIPTION
Also checked German translation and removed "Chrome" from it. Other
translations might have to be checked as well.

"Chrome" is replaced with "Browser"