### PR TITLE
Update icon on launch for paused setting

### DIFF
--- a/app/js/PauseButton.js
+++ b/app/js/PauseButton.js
@@ -1,23 +1,18 @@
 /* @flow */
 
+import { useDispatch, useSelector } from 'react-redux';
 import React from 'react';
 
-// Unpack TW.
-const { settings } = chrome.extension.getBackgroundPage().TW;
-
 export default function PauseButton() {
-  const [paused, setPaused] = React.useState(settings.get('paused'));
+  const dispatch = useDispatch();
+  const paused = useSelector(state => state.settings.paused);
 
   function pause() {
-    chrome.browserAction.setIcon({ path: 'img/icon-paused.png' });
-    settings.set('paused', true);
-    setPaused(true);
+    dispatch({ key: 'paused', type: 'SET_PAUSED_SETTING', value: true });
   }
 
   function play() {
-    chrome.browserAction.setIcon({ path: 'img/icon.png' });
-    settings.set('paused', false);
-    setPaused(false);
+    dispatch({ key: 'paused', type: 'SET_PAUSED_SETTING', value: false });
   }
 
   return (

--- a/app/js/__mocks__/configureMockStore.js
+++ b/app/js/__mocks__/configureMockStore.js
@@ -21,6 +21,7 @@ export default function configureMockStore(
       ...(initialState.localStorage == null ? {} : initialState.localStorage),
     },
     settings: {
+      paused: false,
       theme: 'system',
     },
     tempStorage: {

--- a/app/js/reducers/settingsReducer.js
+++ b/app/js/reducers/settingsReducer.js
@@ -2,21 +2,31 @@
 
 import type { ThemeSettingValue } from '../Types';
 
+type SetPausedAction = {
+  key: 'paused',
+  type: 'SET_PAUSED_SETTING',
+  value: boolean,
+};
+
 type SetThemeSettingAction = {
   key: 'theme',
   type: 'SET_THEME_SETTING',
   value: ThemeSettingValue,
 };
 
-export type Action = SetThemeSettingAction;
+export type Action = SetPausedAction | SetThemeSettingAction;
 
 export type State = {
+  // If TabWrangler is paused (won't count down)
+  paused: boolean,
+
   // Which color theme to use for Tab Wrangler. Can be 'dark', 'light', or 'system'
   theme: ThemeSettingValue,
 };
 
 function createInitialState() {
   return {
+    paused: false,
     theme: 'system',
   };
 }
@@ -24,10 +34,15 @@ function createInitialState() {
 const initialState = createInitialState();
 export default function settingsReducer(state: State = initialState, action: Action) {
   switch (action.type) {
+    case 'SET_PAUSED_SETTING':
+      return {
+        ...state,
+        paused: action.value,
+      };
     case 'SET_THEME_SETTING':
       return {
         ...state,
-        [action.key]: action.value,
+        theme: action.value,
       };
     default:
       return state;

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -36,9 +36,6 @@ const Settings = {
     // How many minutes (+ secondsInactive) before we consider a tab "stale" and ready to close.
     minutesInactive: 20,
 
-    // If TabWrangler is paused (won't count down)
-    paused: false,
-
     // Save closed tabs in between browser sessions.
     purgeClosedTabs: false,
 
@@ -176,20 +173,6 @@ const Settings = {
     tabmanager.tabTimes = {};
     chrome.tabs.query({ windowType: 'normal' }, tabmanager.initTabs);
     Settings.setValue('secondsInactive', value);
-  },
-
-  setpaused(value: boolean) {
-    if (value === false) {
-      // The user has just unpaused, immediately set all tabs to the current time
-      // so they will not be closed.
-      chrome.tabs.query(
-        {
-          windowType: 'normal',
-        },
-        tabmanager.initTabs
-      );
-    }
-    Settings.setValue('paused', value);
   },
 
   setshowBadgeCount(value: boolean) {


### PR DESCRIPTION
Move the "paused" setting into the settings store so it can be watched
and rehydrated like the other settings. This enables updating the icon
in the browser when `settings.paused` changes and when the extension
initially launches.

Closes #292