### PR TITLE
Context menu option to 'lock' specific windows

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -37,6 +37,10 @@
     "description": "Label for context menu item that locks the clicked tab",
     "message": "Never close this tab"
   },
+  "contextMenu_lockWindow": {
+    "description": "Label for context menu item that locks the current window",
+    "message": "Never close this window"
+  },
   "corral_currentSort": {
     "description": "Button title for showing current sort order",
     "message": "Currently sorted $sort_order$",
@@ -292,6 +296,10 @@
   "tabLock_lockedReason_locked": {
     "description": "Label for tab that is locked because the user locked it",
     "message": "Locked"
+  },
+  "tabLock_lockedReason_lockedWindow": {
+    "description": "Label for tab that is locked because the user locked its window",
+    "message": "Locked Window"
   },
   "tabLock_lockedReason_matches": {
     "description": "Label for a tab that is locked because it matches the whitelist",

--- a/app/js/OpenTabRow.tsx
+++ b/app/js/OpenTabRow.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { isLocked, isManuallyLockable } from "./tab";
+import tabmanager from "./tabmanager";
 import { AppState } from "./Types";
 import LazyImage from "./LazyImage";
 import cx from "classnames";
@@ -36,7 +37,7 @@ export default function OpenTabRow(props: Props) {
     if (tab.pinned) {
       reason = chrome.i18n.getMessage("tabLock_lockedReason_pinned");
     } else if (getTW().settings.get("filterAudio") && tab.audible) {
-      reason = <abbr title={chrome.i18n.getMessage("tabLock_lockedReason_audible")}>Locked</abbr>;
+      reason = <abbr title={chrome.i18n.getMessage("tabLock_lockedReason_audible")}>{chrome.i18n.getMessage("tabLock_lockedReason_locked")}</abbr>;
     } else if (getTW().settings.get("filterGroupedTabs") && "groupId" in tab && tab.groupId > 0) {
       reason = chrome.i18n.getMessage("tabLock_lockedReason_group");
     } else if (tabWhitelistMatch) {
@@ -45,6 +46,8 @@ export default function OpenTabRow(props: Props) {
           Auto-Locked
         </abbr>
       );
+    } else if (tabmanager.isLockedWindow(tab.windowId)) {
+      reason = chrome.i18n.getMessage("tabLock_lockedReason_lockedWindow");
     } else {
       reason = chrome.i18n.getMessage("tabLock_lockedReason_locked");
     }

--- a/app/js/settings.ts
+++ b/app/js/settings.ts
@@ -2,6 +2,7 @@ import tabmanager from "./tabmanager";
 
 const defaultCache: Record<string, unknown> = {};
 const defaultLockedIds: Array<number> = [];
+const defaultLockedWindowIds: Array<number> = [];
 
 const Settings = {
   cache: defaultCache,
@@ -23,7 +24,11 @@ const Settings = {
     filterGroupedTabs: false,
 
     // An array of tabids which have been explicitly locked by the user.
+    // TODO: rename to `lockedTabIds`?
     lockedIds: defaultLockedIds,
+    
+    // An array of window ids which have been explicitly locked by the user.
+    lockedWindowIds: defaultLockedWindowIds,
 
     // Saved sort order for list of open tabs. When null, default sort is used (tab order)
     lockTabSortOrder: null,

--- a/app/js/tab.ts
+++ b/app/js/tab.ts
@@ -3,6 +3,7 @@ import { getTW } from "./util";
 export function isLocked(tab: chrome.tabs.Tab): boolean {
   const { settings, tabmanager } = getTW();
   const lockedIds = settings.get<Array<number>>("lockedIds");
+  const lockedWindowIds = settings.get<Array<number>>("lockedWindowIds");
   const tabWhitelistMatch = tabmanager.getWhitelistMatch(tab.url);
   return (
     tab.pinned ||
@@ -10,17 +11,20 @@ export function isLocked(tab: chrome.tabs.Tab): boolean {
     (tab.id != null && lockedIds.indexOf(tab.id) !== -1) ||
     !!(settings.get("filterGroupedTabs") && "groupId" in tab && tab.groupId > 0) ||
     !!(tab.audible && settings.get("filterAudio"))
+    || (tab.windowId != null && lockedWindowIds.indexOf(tab.windowId) !== -1)
   );
 }
 
 export function isManuallyLockable(tab: chrome.tabs.Tab): boolean {
   const { settings, tabmanager } = getTW();
   const tabWhitelistMatch = tabmanager.getWhitelistMatch(tab.url);
+  const lockedWindowIds = settings.get<Array<number>>("lockedWindowIds");
   return (
     !tab.pinned &&
     !tabWhitelistMatch &&
     !(tab.audible && settings.get("filterAudio")) &&
     // $FlowFixMe missing groupId in chrome.tab
     !(settings.get("filterGroupedTabs") && "groupId" in tab && tab.groupId > 0)
+    && !(tab.windowId != null && lockedWindowIds.indexOf(tab.windowId) !== -1)
   );
 }


### PR DESCRIPTION
Resolves #13
Resolves #346 

Also included: unchecking an option in the context menu will actually behave as intended (previously, the context menu could not unlock tabs)