### PR TITLE
Add support for longer inactive time periods

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -267,15 +267,23 @@
   },
   "options_option_timeInactive_minutes": {
     "description": "Input title for number of minutes before closing tabs",
-    "message": "Must be a number greater than 0 and less than 7200"
+    "message": "Must be a number greater or equal to 0 and less than 60"
   },
   "options_option_timeInactive_postLabel": {
     "description": "Label following inputs for setting inactive time before tabs are closed",
-    "message": "minutes : seconds"
+    "message": "hours : minutes : seconds"
   },
   "options_option_timeInactive_seconds": {
     "description": "Input title for number of seconds before closing tabs",
-    "message": "Must be a number greater than 0 and less than 60"
+    "message": "Must be a number greater or equal to 0 and less than 60"
+  },
+  "options_option_timeInactive_hours": {
+    "description": "Input title for number of hours before closing tabs",
+    "message": "Must be a number greater or equal to 0 and less than 24"
+  },
+  "options_option_timeInactive_days": {
+    "description": "Input title for number of days before closing tabs",
+    "message": "Must be a number greater or equal to 0 and less than 30"
   },
   "options_saving": {
     "description": "Message displayed when options are being saved",

--- a/app/js/OptionsTab.tsx
+++ b/app/js/OptionsTab.tsx
@@ -305,9 +305,33 @@ class OptionsTab extends React.Component<OptionsTabProps, OptionsTabState> {
             <div className="form-inline">
               <input
                 className="form-control form-control--time"
+                defaultValue{getTW().settings.get("daysInactive")}
+                id="daysInactive"
+                max="30"
+                min="0"
+                name="daysInactive"
+                onChange={this._debouncedHandleSettingsChange}
+                title={chrome.i18n.getMessage("options_option_timeInactive_days")}
+                type="number"
+              />
+              <span className="mx-1">days </span>
+              <input
+                className="form-control form-control--time"
+                defaultValue{getTW().settings.get("hoursInactive")}
+                id="hoursInactive"
+                max="24"
+                min="0"
+                name="hoursInactive"
+                onChange={this._debouncedHandleSettingsChange}
+                title={chrome.i18n.getMessage("options_option_timeInactive_hours")}
+                type="number"
+              />
+              <span className="mx-1"> : </span>
+              <input
+                className="form-control form-control--time"
                 defaultValue={getTW().settings.get("minutesInactive")}
                 id="minutesInactive"
-                max="7200"
+                max="60"
                 min="0"
                 name="minutesInactive"
                 onChange={this._debouncedHandleSettingsChange}


### PR DESCRIPTION
My wife likes using a different extension that is firefox-only, and she likes setting it to 2 weeks (which cannot be done in options as of currently).
This adds support for days and hours in the settings.
Days max out at 30 days.
Other periods max out the same way seconds currently do.
I also fix the issue where max minutes were not enforced in the set function.