### PR TITLE
Move `tabTimes` into browser extension storage

### DIFF
--- a/app/js/OpenTabRow.tsx
+++ b/app/js/OpenTabRow.tsx
@@ -18,7 +18,11 @@ type Props = {
 };
 
 export default function OpenTabRow(props: Props) {
+  const { tab } = props;
   const paused = useSelector((state: AppState) => state.settings.paused);
+  const tabTime = useSelector((state: AppState) =>
+    tab.id == null ? Date.now() : state.localStorage.tabTimes[tab.id]
+  );
 
   function handleLockedOnClick(event: React.MouseEvent) {
     // Dynamic type check to ensure target is an input element.
@@ -26,7 +30,6 @@ export default function OpenTabRow(props: Props) {
     props.onToggleTab(props.tab, event.target.checked, event.shiftKey);
   }
 
-  const { tab } = props;
   const tabWhitelistMatch = getTW().tabmanager.getWhitelistMatch(tab.url);
   const tabIsLocked = isLocked(tab);
 
@@ -59,9 +62,8 @@ export default function OpenTabRow(props: Props) {
     if (paused) {
       timeLeftContent = chrome.i18n.getMessage("tabLock_lockedReason_paused");
     } else {
-      const lastModified = tab.id == null ? Date.now() : getTW().tabmanager.tabTimes[tab.id];
       const cutOff = new Date().getTime() - getTW().settings.get<number>("stayOpen");
-      const timeLeft = -1 * Math.round((cutOff - lastModified) / 1000);
+      const timeLeft = -1 * Math.round((cutOff - tabTime) / 1000);
       // If `timeLeft` is less than 0, the countdown likely continued and is waiting for the
       // interval to clean up this tab. It's also possible the number of tabs is not below
       // `minTabs`, which has stopped the countdown and locked this at a negative `timeLeft` until

--- a/app/js/Popup.tsx
+++ b/app/js/Popup.tsx
@@ -75,3 +75,5 @@ export default function Popup() {
     </>
   );
 }
+
+// [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Dead_object

--- a/app/js/reducers/localStorageReducer.ts
+++ b/app/js/reducers/localStorageReducer.ts
@@ -7,9 +7,24 @@ export type RemoveSavedTabsAction = {
   type: "REMOVE_SAVED_TABS";
 };
 
+type RemoveTabTime = {
+  tabId: string;
+  type: "REMOVE_TAB_TIME";
+};
+
+type ResetTabTimes = {
+  type: "RESET_TAB_TIMES";
+};
+
 export type SetSavedTabsAction = {
   savedTabs: Array<chrome.tabs.Tab>;
   type: "SET_SAVED_TABS";
+};
+
+type SetTabTime = {
+  tabId: string;
+  tabTime: number;
+  type: "SET_TAB_TIME";
 };
 
 export type SetTotalTabsRemovedAction = {
@@ -30,7 +45,10 @@ export type SetTotalTabsWrangledAction = {
 export type Action =
   | RemoveAllSavedTabsAction
   | RemoveSavedTabsAction
+  | RemoveTabTime
+  | ResetTabTimes
   | SetSavedTabsAction
+  | SetTabTime
   | SetTotalTabsRemovedAction
   | SetTotalTabsUnwrangledAction
   | SetTotalTabsWrangledAction;
@@ -40,6 +58,10 @@ export type State = {
   installDate: number;
   // Tabs closed by Tab Wrangler
   savedTabs: Array<chrome.tabs.Tab>;
+  // Map of tabId -> time remaining before tab is closed
+  tabTimes: {
+    [tabid: string]: number;
+  };
   // Number of tabs closed by any means since install
   totalTabsRemoved: number;
   // Number of tabs unwrangled (re-opened from the corral) since install
@@ -52,6 +74,7 @@ export function createInitialState(): State {
   return {
     installDate: Date.now(),
     savedTabs: [],
+    tabTimes: {},
     totalTabsRemoved: 0,
     totalTabsUnwrangled: 0,
     totalTabsWrangled: 0,
@@ -79,6 +102,27 @@ export default function localStorage(state: State = initialState, action: Action
       return {
         ...state,
         savedTabs: action.savedTabs,
+      };
+    case "RESET_TAB_TIMES":
+      return {
+        ...state,
+        tabTimes: {},
+      };
+    case "REMOVE_TAB_TIME": {
+      const nextTabTimes = { ...state.tabTimes };
+      delete nextTabTimes[action.tabId];
+      return {
+        ...state,
+        tabTimes: nextTabTimes,
+      };
+    }
+    case "SET_TAB_TIME":
+      return {
+        ...state,
+        tabTimes: {
+          ...state.tabTimes,
+          [action.tabId]: action.tabTime,
+        },
       };
     case "SET_TOTAL_TABS_REMOVED":
       return {

--- a/app/js/settings.ts
+++ b/app/js/settings.ts
@@ -171,7 +171,7 @@ const Settings = {
     }
 
     // Reset the tabTimes since we changed the setting
-    tabmanager.tabTimes = {};
+    tabmanager.resetTabTimes();
     chrome.tabs.query({ windowType: "normal" }, tabmanager.initTabs);
     Settings.setValue("minutesInactive", value);
   },
@@ -188,7 +188,7 @@ const Settings = {
     }
 
     // Reset the tabTimes since we changed the setting
-    tabmanager.tabTimes = {};
+    tabmanager.resetTabTimes();
     chrome.tabs.query({ windowType: "normal" }, tabmanager.initTabs);
     Settings.setValue("secondsInactive", value);
   },

--- a/app/popup.tsx
+++ b/app/popup.tsx
@@ -7,6 +7,7 @@ import Popup from "./js/Popup";
 import { Provider } from "react-redux";
 import React from "react";
 import ReactDOM from "react-dom";
+import configureStore from "./js/configureStore";
 import { connect } from "react-redux";
 
 const popupElement = document.getElementById("popup");
@@ -18,12 +19,12 @@ if (popupElement != null) {
     throw new Error("Reopen the page or popup. Background page does not exist.");
   }
 
+  const { persistor, store } = configureStore();
   const ConnectedPopup = connect()(Popup);
-  const TW = backgroundPage.TW;
 
   ReactDOM.render(
-    <Provider store={TW.store}>
-      <PersistGate loading={null} persistor={TW.persistor}>
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
         <ConnectedPopup />
       </PersistGate>
     </Provider>,
@@ -39,5 +40,3 @@ if (popupElement != null) {
 
   window.addEventListener("pagehide", unmountPopup);
 }
-
-// [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Dead_object


### PR DESCRIPTION
* Enables both popup and background script to access `tabTimes` without requiring a global
* Rehydrates tab times across browser restarts

Partially addresses #130