### PR TITLE
Update tab info correctly for `onReplaced` event

### DIFF
--- a/app/js/tabUtil.ts
+++ b/app/js/tabUtil.ts
@@ -144,11 +144,6 @@ export async function updateLastAccessed(tabOrTabId: chrome.tabs.Tab | number): 
   }
 }
 
-export async function replaceTab(addedTabId: number, removedTabId: number) {
-  await removeTab(removedTabId);
-  await updateLastAccessed(addedTabId);
-}
-
 export function getWhitelistMatch(
   url: string | undefined,
   { whitelist }: { whitelist: string[] },


### PR DESCRIPTION
The `onReplaced` event is fired when a tab is discarded, which is something that happens frequently in both Firefox and in Chrome. Update the tab's ID in the list of locked IDs as well as in the list of tab times to correctly maintain state after `onReplaced`.

This also stops counting "discarded" tabs as tabs closed tabs, which may have reduced Tab Wrangler close rate by incorrectly incrementing denominator of (tabs closed by tab wrangler / all tabs closed).

Closes #462
Closes #468