### PR TITLE
Make maxTabs configurable based on available storage quota, instead of using an hardcoded limit.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -389,9 +389,23 @@
       }
     }
   },
-  "settings_setmaxTabs_error": {
+  "settings_setmaxTabs_error_invalid": {
     "description": "Error shown when invalid max tabs setting is supplied.",
-    "message": "Max tabs must be a number between 1 and 1000"
+    "message": "Max tabs must be a number greater than 1"
+  },
+  "settings_setmaxTabs_error_too_big": {
+    "description": "Error shown when the supplied max tabs setting could exceed quota.",
+    "message": "Max tabs must not exceed the bound allowed by storage quota ( $upperBound$ tabs, estimated from $quota$ bytes of storage quota)",
+    "placeholders": {
+      "upperBound": {
+        "content": "$1",
+        "example": "18"
+      },
+      "quota": {
+        "content": "$2",
+        "example": "5242880"
+      }
+    }
   },
   "settings_setminTabs_error": {
     "description": "Error shown when invalid min tabs setting is supplied.",

--- a/app/js/__tests__/settings.test.ts
+++ b/app/js/__tests__/settings.test.ts
@@ -22,7 +22,7 @@ describe("settings", () => {
     expect(() => Settings.setmaxTabs("0")).toThrowError();
   });
 
-  test("throws an exception when maxTabs is > 1000", () => {
-    expect(() => Settings.setmaxTabs("1100")).toThrowError();
+  test("throws an exception when maxTabs would exceed browser quota", () => {
+    expect(() => Settings.setmaxTabs("10000")).toThrowError();
   });
 });

--- a/app/js/queries.ts
+++ b/app/js/queries.ts
@@ -17,6 +17,9 @@ export async function getStorageSyncPersist(): Promise<StorageSyncPersistState> 
   return Object.assign({}, STORAGE_SYNC_PERSIST_DEFAULTS, data["persist:settings"]);
 }
 
+// StorageLocalPersistState grows linearly with the size of tabTimes and savedTabs
+// We defined an estimate of the size of an individual tab at tabUtil.AVERAGE_TAB_BYTES_SIZE
+
 export type StorageLocalPersistState = {
   // Date of installation of Tab Wrangler
   installDate: number;

--- a/app/js/tabUtil.ts
+++ b/app/js/tabUtil.ts
@@ -9,6 +9,8 @@ import settings from "./settings";
 
 type WrangleOption = "exactURLMatch" | "hostnameAndTitleMatch" | "withDuplicates";
 
+export const AVERAGE_TAB_BYTES_SIZE = 600;
+
 export function findPositionByURL(savedTabs: chrome.tabs.Tab[], url: string | null = ""): number {
   return savedTabs.findIndex((item: chrome.tabs.Tab) => item.url === url && url != null);
 }

--- a/app/js/tabUtil.ts
+++ b/app/js/tabUtil.ts
@@ -83,8 +83,12 @@ export function wrangleTabs(
 
   // Trim saved tabs to the max allocated by the setting. Browser extension storage is limited and
   // thus cannot allow saved tabs to grow indefinitely.
-  if (storageLocalPersist.savedTabs.length - maxTabs > 0)
+  if (storageLocalPersist.savedTabs.length - maxTabs > 0) {
+    const tabsToTrim = storageLocalPersist.savedTabs.splice(maxTabs);
+    console.log("Exceeded maxTabs (%d), trimming older tabs:", maxTabs);
+    console.log(tabsToTrim.map((t) => t.url));
     storageLocalPersist.savedTabs = storageLocalPersist.savedTabs.splice(0, maxTabs);
+  }
 }
 
 export async function wrangleTabsAndPersist(tabs: Array<chrome.tabs.Tab>) {


### PR DESCRIPTION
I recently started to use Tabwrangler, but I soon realised that I exceeded 2700 tabs wrangled... I wanted to check/review old tabs that got wrangled, but I unfortunately realised that they got trimmed away, because of the 1000 tabs limit.

I then tried to increase this limit, but disappointingly realised that the default is also the maximum value accepted by Tabwrangler :disappointed: 

I'm using tabwrangler to avoid having to remember about tidying up old tabs before the systems starts to become unresponsive, and avoid worrying about losing old context/state by just getting rid of all old tabs (evicting the oldest ones first makes a lot of sense). Knowing that I wouldn't be able to go back and inspect what has been added to the corral brought the worry back (which is why I kept Tabwrangler paused for the last couple of months).

1000 tabs seems a relatively low amount in 2024, so I decided to look into how much each tab weighs (in my experience, little more than 500 bytes each on average), how much storage quota the browser can make available to us and make the maxTabs setting configurable based on that.

While I was at it, I also added a logging statement for when Tabwrangler is finally forced to trim its corral (so at least this operation is not completely silent, and people might open the console to check what has been lost).


