### PR TITLE
Explicitly state "page" context for context menu entries

### DIFF
--- a/app/js/menus.ts
+++ b/app/js/menus.ts
@@ -20,17 +20,20 @@ export default class Menus {
       id: "corralTab",
       title: chrome.i18n.getMessage("contextMenu_corralTab"),
       type: "normal",
+      contexts: ["page"],
     });
     chrome.contextMenus.create({ id: "separator", type: "separator" });
     chrome.contextMenus.create({
       id: "lockTab",
       title: chrome.i18n.getMessage("contextMenu_lockTab"),
       type: "checkbox",
+      contexts: ["page"],
     });
     chrome.contextMenus.create({
       id: "lockDomain",
       title: chrome.i18n.getMessage("contextMenu_lockDomain"),
       type: "checkbox",
+      contexts: ["page"],
     });
   }
 


### PR DESCRIPTION
This PR adds explicit statement of "page" context for context menu entries, because in Firefox it for some reason defaults to "all", resulting in Tab Wrangler entry showing up in all types of context menus (page, link, image, input field etc), which doesn't happen in Chrome.