### PR TITLE
Added shortcut support to open TabWrangler popup

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,10 @@
     "description": "Description of keyboard shortcut to close and save the active tab",
     "message": "Close and save the active tab"
   },
+  "commandWrangleOpenPopup": {
+    "description": "Description of keyboard shortcut to open TabWrangler popup",
+    "message": "Open popup"
+  },
   "contextMenu_corralTab": {
     "description": "Label for context menu item that closes the clicked tab and adds it to the corral",
     "message": "Close tab and save URL immediately"

--- a/app/manifest.template.json
+++ b/app/manifest.template.json
@@ -21,6 +21,9 @@
     },
     "wrangle-current-tab": {
       "description": "__MSG_commandWrangleCurrentTab__"
+    },
+    "_execute_action": {
+      "description": "__MSG_commandWrangleShowPopup__"
     }
   },
   "minimum_chrome_version": "88",
@@ -28,11 +31,21 @@
     "open_in_tab": true,
     "page": "popup.html"
   },
-  "permissions": ["alarms", "contextMenus", "sessions", "storage", "tabs"],
+  "permissions": [
+    "alarms",
+    "contextMenus",
+    "sessions",
+    "storage",
+    "tabs"
+  ],
   "web_accessible_resources": [
     {
-      "matches": ["*://*/*"],
-      "resources": ["img/icon48.png"]
+      "matches": [
+        "*://*/*"
+      ],
+      "resources": [
+        "img/icon48.png"
+      ]
     }
   ]
 }

--- a/app/manifest.template.json
+++ b/app/manifest.template.json
@@ -31,21 +31,11 @@
     "open_in_tab": true,
     "page": "popup.html"
   },
-  "permissions": [
-    "alarms",
-    "contextMenus",
-    "sessions",
-    "storage",
-    "tabs"
-  ],
+  "permissions": ["alarms", "contextMenus", "sessions", "storage", "tabs"],
   "web_accessible_resources": [
     {
-      "matches": [
-        "*://*/*"
-      ],
-      "resources": [
-        "img/icon48.png"
-      ]
+      "matches": ["*://*/*"],
+      "resources": ["img/icon48.png"]
     }
   ]
 }

--- a/app/manifest.template.json
+++ b/app/manifest.template.json
@@ -21,9 +21,6 @@
     },
     "wrangle-current-tab": {
       "description": "__MSG_commandWrangleCurrentTab__"
-    },
-    "_execute_action": {
-      "description": "__MSG_commandWrangleOpenPopup__"
     }
   },
   "minimum_chrome_version": "88",

--- a/app/manifest.template.json
+++ b/app/manifest.template.json
@@ -23,7 +23,7 @@
       "description": "__MSG_commandWrangleCurrentTab__"
     },
     "_execute_action": {
-      "description": "__MSG_commandWrangleShowPopup__"
+      "description": "__MSG_commandWrangleOpenPopup__"
     }
   },
   "minimum_chrome_version": "88",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,6 +139,11 @@ module.exports = [
               // Sync extension version to the version in package.json.
               manifest.version = package.version;
 
+              // Supports extension popup activation shortcut
+              manifest.commands["_execute_action"] = {
+                "description": "__MSG_commandWrangleOpenPopup__"
+              };
+
               return JSON.stringify(manifest, null, 2);
             },
           },


### PR DESCRIPTION
This PR introduces a keyboard shortcut feature that allows users to quickly open the TabWrangler popup without clicking the toolbar button.