### PR TITLE
Give Crowdin action required "write" permissions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,7 +1,7 @@
 name: Crowdin Action
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:


### PR DESCRIPTION
Per Crowdin docs, their action requires "write" permissions.

See https://github.com/crowdin/github-action?tab=readme-ov-file#permissions