### PR TITLE
Render tab groups in the Lock Tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Tab Wrangler's requested permissions are listed in its
 - [`"storage"`][5]: Allows syncing your Tab Wrangler settings with your browser account and enables
   saving your closed tabs to your local computer. _Note: closed tabs are not synced because the
   "sync" storage area has only a small amount of storage._
+- [`"tabGroups"`][10]: Allows creating tab groups and reading their details, like their color, to
+  show matching tab group colors in Tab Wrangler's own interface.
 - [`"tabs"`][6]: Allows reading the title and location of any current tabs as well as closing those
   tabs and opening new tabs. This permission **does not** enable Tab Wrangler to read information on
   web pages that you visit.
@@ -192,7 +194,7 @@ Pull requests for bug fixes and features are more than welcome. Please check out
 ["Developing" section][2] of the CONTRIBUTING doc to see how to get started. Once your code is
 working and tested, submit a pull request to this primary project and we'll get going.
 
-- Modernized and maintained by [ssorallen](https://github.com/ssorallen) in 2017
+- Modernized and maintained by [ssorallen](https://github.com/ssorallen) since 2017
 - Rewritten by [JacobSingh](https://github.com/jacobSingh) in 2012
 - Original extension and idea by [jacktasia](https://github.com/jacktasia) in 2010
 
@@ -207,3 +209,4 @@ working and tested, submit a pull request to this primary project and we'll get 
 [7]: https://developer.chrome.com/docs/extensions/reference/alarms/
 [8]: https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria
 [9]: https://developer.chrome.com/docs/extensions/how-to/ui/favicons
+[10]: https://developer.chrome.com/docs/extensions/reference/api/tabGroups

--- a/app/js/CorralTab/CorralTab.tsx
+++ b/app/js/CorralTab/CorralTab.tsx
@@ -277,11 +277,7 @@ export default function CorralTab() {
     };
   }, []);
 
-  async function handleOpenTab(
-    tab: chrome.tabs.Tab,
-    session: chrome.sessions.Session | null | undefined,
-  ) {
-    if (session == null) return;
+  async function handleOpenTab(tab: chrome.tabs.Tab, session: chrome.sessions.Session | undefined) {
     await restoreTabs([{ session, tab }]);
     setSelectedTabs((prev) => {
       const next = new Set(prev);

--- a/app/js/LockTab/LockTab.css
+++ b/app/js/LockTab/LockTab.css
@@ -1,0 +1,16 @@
+:root {
+  --tw-tab-group-color-cyan: #78D9EC;
+  --tw-tab-group-color-blue: #8AB4F8;
+  --tw-tab-group-color-green: #81C995;
+  --tw-tab-group-color-grey: #BCC1C6;
+  --tw-tab-group-color-orange: #FCAD70;
+  --tw-tab-group-color-pink: #FF8BCB;
+  --tw-tab-group-color-purple: #D7AEFB;
+  --tw-tab-group-color-red: #F28B82;
+  --tw-tab-group-color-yellow: #FDD663;
+}
+
+/* Hide bottom border of final child to prevent double border from window container */
+.table>tbody:last-child>tr:last-child>td {
+  border-bottom: 0;
+}

--- a/app/js/LockTab/LockTab.tsx
+++ b/app/js/LockTab/LockTab.tsx
@@ -1,3 +1,4 @@
+import "./LockTab.css";
 import { createContext, useEffect, useMemo, useRef, useState } from "react";
 import { lockTabId, lockWindowId, unlockTabId, unlockWindowId } from "../storage";
 import settings, { type LockTabSortOrderOption } from "../settings";
@@ -7,6 +8,8 @@ import Dropdown from "react-bootstrap/Dropdown";
 import OpenTabRow from "./OpenTabRow";
 import cx from "classnames";
 import { useStorageSyncQuery } from "../storage";
+import useTabGroupsQuery from "./useTabGroupsQuery";
+import useTabsQuery from "./useTabsQuery";
 
 interface Sorter {
   key: LockTabSortOrderOption;
@@ -95,6 +98,41 @@ const ReverseTabOrderSorter: Sorter = {
   },
 };
 
+interface TabSegmentTab {
+  isFirstInGroup: boolean;
+  tab: chrome.tabs.Tab;
+}
+
+type TabSegment =
+  | { type: "ungrouped"; tabs: TabSegmentTab[] }
+  | { type: "group"; groupId: number; tabs: TabSegmentTab[] };
+
+function groupTabsIntoSegments(tabs: chrome.tabs.Tab[]): TabSegment[] {
+  const segments: TabSegment[] = [];
+  const seenGroupIds = new Set<number>();
+  for (const tab of tabs) {
+    const groupId = tab.groupId != null && tab.groupId > 0 ? tab.groupId : null;
+    const last = segments[segments.length - 1];
+    if (groupId != null && last?.type === "group" && last.groupId === groupId) {
+      last.tabs.push({ isFirstInGroup: false, tab });
+    } else if (groupId == null && last?.type === "ungrouped") {
+      last.tabs.push({ isFirstInGroup: false, tab });
+    } else {
+      segments.push(
+        groupId == null
+          ? { type: "ungrouped", tabs: [{ isFirstInGroup: !seenGroupIds.has(tab.groupId), tab }] }
+          : {
+              type: "group",
+              groupId,
+              tabs: [{ isFirstInGroup: !seenGroupIds.has(tab.groupId), tab }],
+            },
+      );
+    }
+    if (groupId != null) seenGroupIds.add(groupId);
+  }
+  return segments;
+}
+
 const DEFAULT_SORTER = TabOrderSorter;
 const Sorters = [
   TabOrderSorter,
@@ -121,30 +159,6 @@ function useNow() {
     };
   }, []);
   return now;
-}
-
-function useTabsQuery() {
-  const queryClient = useQueryClient();
-  const query = useQuery({
-    queryFn: () => chrome.tabs.query({}),
-    queryKey: ["tabsQuery"],
-  });
-  useEffect(() => {
-    function invalidateTabsQuery() {
-      queryClient.invalidateQueries({ queryKey: ["tabsQuery"] });
-    }
-    chrome.tabs.onActivated.addListener(invalidateTabsQuery);
-    chrome.tabs.onCreated.addListener(invalidateTabsQuery);
-    chrome.tabs.onRemoved.addListener(invalidateTabsQuery);
-    chrome.tabs.onUpdated.addListener(invalidateTabsQuery);
-    return () => {
-      chrome.tabs.onActivated.removeListener(invalidateTabsQuery);
-      chrome.tabs.onCreated.removeListener(invalidateTabsQuery);
-      chrome.tabs.onRemoved.removeListener(invalidateTabsQuery);
-      chrome.tabs.onUpdated.removeListener(invalidateTabsQuery);
-    };
-  }, [queryClient]);
-  return query;
 }
 
 function useTabTimesQuery() {
@@ -195,6 +209,9 @@ export default function LockTab() {
 
   const tabsQuery = useTabsQuery();
   const tabTimesQuery = useTabTimesQuery();
+  const tabGroupsQuery = useTabGroupsQuery();
+  const tabGroupsById = new Map((tabGroupsQuery.data ?? []).map((group) => [group.id, group]));
+
   const tabsByWindowId: Array<[number, chrome.tabs.Tab[]]> = useMemo(() => {
     const tabs =
       tabsQuery.data == null || tabTimesQuery.data == null
@@ -217,10 +234,10 @@ export default function LockTab() {
   }, [currSorter, currWindow?.id, tabTimesQuery.data, tabsQuery.data]);
 
   const { data: syncData } = useStorageSyncQuery();
-  const lockedWindowIds: number[] = syncData?.lockedWindowIds ?? [];
+  const lockedWindowIds: Set<number> = new Set(syncData?.lockedWindowIds ?? []);
 
   async function toggleWindow(windowId: number) {
-    if (lockedWindowIds.indexOf(windowId) !== -1) {
+    if (lockedWindowIds.has(windowId)) {
       await unlockWindowId(windowId);
     } else {
       await lockWindowId(windowId);
@@ -321,75 +338,115 @@ export default function LockTab() {
       </div>
       <div className="d-flex flex-column gap-4">
         <UseNowContext.Provider value={now}>
-          {tabsByWindowId.map(([windowId, tabs]) => {
-            const isLocked = lockedWindowIds.indexOf(windowId) !== -1;
-            return (
-              <div className="border overflow-hidden rounded" key={windowId}>
-                <table className="table table-hover table-sm mb-0">
-                  <thead>
-                    <tr>
-                      <th
-                        className={cx("p-2 align-middle", {
-                          "table-warning": isLocked,
-                          "bg-body-tertiary": !isLocked,
-                        })}
-                        colSpan={5}
-                      >
-                        <div className="d-flex justify-content-between align-items-center">
-                          <div className="d-flex align-items-center gap-2">
-                            <abbr title={`ID: ${windowId}`}>Window</abbr>
-                            {currWindow?.id === windowId && (
-                              <span className="badge text-bg-success position-relative">
-                                CURRENT
-                              </span>
-                            )}
-                          </div>
-                          <Button
-                            active={isLocked}
-                            className="d-flex align-items-center gap-1"
-                            // @ts-expect-error Need to expand size type to include "xs"
-                            size="xs"
-                            type="button"
-                            variant="outline-secondary"
-                            onClick={() => toggleWindow(windowId)}
-                          >
-                            {isLocked ? (
-                              <>
-                                Locked <i className="fas fa-lock" />
-                              </>
-                            ) : (
-                              <>
-                                Unlocked <i className="fas fa-unlock" />
-                              </>
-                            )}
-                          </Button>
-                        </div>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {tabs.map((tab, index) => (
-                      <OpenTabRow
-                        isLast={index === tabs.length - 1}
-                        key={tab.id}
-                        onToggleTab={toggleTab}
-                        tab={tab}
-                        tabTime={
-                          tabTimesQuery.data == null || tab.id == null
-                            ? undefined
-                            : tabTimesQuery.data[tab.id]
-                        }
-                        windowId={windowId}
-                        windowLocked={lockedWindowIds.indexOf(windowId) !== -1}
-                      />
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            );
-          })}
+          {tabsByWindowId.map(([windowId, tabs]) => (
+            <WindowCard
+              isCurrent={currWindow?.id === windowId}
+              isLocked={lockedWindowIds.has(windowId)}
+              key={windowId}
+              windowId={windowId}
+              tabGroupsById={tabGroupsById}
+              tabs={tabs}
+              tabTimes={tabTimesQuery.data}
+              onToggle={toggleWindow}
+              onToggleTab={toggleTab}
+            />
+          ))}
         </UseNowContext.Provider>
       </div>
+    </div>
+  );
+}
+
+function WindowCard({
+  isCurrent,
+  isLocked,
+  windowId,
+  tabGroupsById,
+  tabs,
+  tabTimes,
+  onToggle,
+  onToggleTab,
+}: {
+  isCurrent: boolean;
+  isLocked: boolean;
+  windowId: number;
+  tabGroupsById: Map<number, chrome.tabGroups.TabGroup>;
+  tabs: chrome.tabs.Tab[];
+  tabTimes: Record<number, number> | undefined;
+  onToggle: (windowId: number) => void;
+  onToggleTab: (
+    windowId: number,
+    tab: chrome.tabs.Tab,
+    selected: boolean,
+    multiselect: boolean,
+  ) => void;
+}) {
+  const segments = groupTabsIntoSegments(tabs);
+  const windowHasGroups = segments.some((s) => s.type === "group");
+  const tbodies = segments.map((segment, segIndex) => {
+    return (
+      <tbody key={segIndex}>
+        {segment.tabs.map(({ tab, isFirstInGroup }) => (
+          <OpenTabRow
+            isFirstInGroup={segment.type === "group" && isFirstInGroup}
+            key={tab.id}
+            tab={tab}
+            tabGroup={segment.type === "group" ? tabGroupsById.get(segment.groupId) : undefined}
+            tabTime={tabTimes == null || tab.id == null ? undefined : tabTimes[tab.id]}
+            windowHasGroups={windowHasGroups}
+            windowId={windowId}
+            windowLocked={isLocked}
+            onToggleTab={onToggleTab}
+          />
+        ))}
+      </tbody>
+    );
+  });
+
+  return (
+    <div className="border overflow-hidden rounded" key={windowId}>
+      <table className="table table-hover table-sm mb-0">
+        <thead>
+          <tr>
+            <th
+              className={cx("p-2 align-middle", {
+                "table-warning": isLocked,
+                "bg-body-tertiary": !isLocked,
+              })}
+              colSpan={4}
+            >
+              <div className="d-flex justify-content-between align-items-center">
+                <div className="d-flex align-items-center gap-2">
+                  <abbr title={`ID: ${windowId}`}>Window</abbr>
+                  {isCurrent && (
+                    <span className="badge text-bg-success position-relative">CURRENT</span>
+                  )}
+                </div>
+                <Button
+                  active={isLocked}
+                  className="d-flex align-items-center gap-1"
+                  // @ts-expect-error Need to expand size type to include "xs"
+                  size="xs"
+                  type="button"
+                  variant="outline-secondary"
+                  onClick={() => onToggle(windowId)}
+                >
+                  {isLocked ? (
+                    <>
+                      Locked <i className="fas fa-lock" />
+                    </>
+                  ) : (
+                    <>
+                      Unlocked <i className="fas fa-unlock" />
+                    </>
+                  )}
+                </Button>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        {tbodies}
+      </table>
     </div>
   );
 }

--- a/app/js/LockTab/OpenTabRow.css
+++ b/app/js/LockTab/OpenTabRow.css
@@ -1,0 +1,14 @@
+.OpenTabRow-group-indicator {
+  border-radius: 5px;
+  height: 20px;
+  width: 20px;
+}
+
+.OpenTabRow-group-border {
+  background-color: transparent;
+  bottom: 0;
+  right: 0;
+  position: absolute;
+  top: 0;
+  width: 3px;
+}

--- a/app/js/LockTab/OpenTabRow.tsx
+++ b/app/js/LockTab/OpenTabRow.tsx
@@ -1,3 +1,4 @@
+import "./OpenTabRow.css";
 import TabFavicon from "../TabFavicon";
 import type { TabLockStatus } from "../tabUtil";
 import { UseNowContext } from "./LockTab";
@@ -7,9 +8,11 @@ import { useContext } from "react";
 import { useStorageSyncPersistQuery } from "../storage";
 
 interface OpenTabRowProps {
-  isLast: boolean;
+  isFirstInGroup?: boolean;
   tab: chrome.tabs.Tab;
+  tabGroup?: chrome.tabGroups.TabGroup;
   tabTime: number | undefined;
+  windowHasGroups?: boolean;
   windowId: number;
   windowLocked: boolean;
   onToggleTab: (
@@ -21,26 +24,37 @@ interface OpenTabRowProps {
 }
 
 export default function OpenTabRow({
-  isLast,
+  isFirstInGroup = false,
   tab,
+  tabGroup,
   tabTime = Date.now(),
+  windowHasGroups = false,
   windowId,
   windowLocked,
   onToggleTab,
 }: OpenTabRowProps) {
   const tabLockStatus = settings.getTabLockStatus(tab);
+  const { data: syncPersistData } = useStorageSyncPersistQuery();
+  const now = useContext(UseNowContext);
+  const paused = syncPersistData?.paused;
+  const cutOff = now - settings.stayOpen();
+  const timeRemaining = -1 * Math.round((cutOff - tabTime) / 1000);
+  const isOverdue = !tabLockStatus.locked && !windowLocked && !paused && timeRemaining < 0;
 
   function setTabActive() {
     if (tab.id == null) return;
     chrome.tabs.update(tab.id, { active: true });
   }
 
+  let groupColor: string | undefined;
+  if (tabGroup != null) {
+    groupColor =
+      tabGroup.color != null ? `var(--tw-tab-group-color-${tabGroup.color})` : "var(--bs-primary)";
+  }
+
   return (
-    <tr className={tab.active ? "table-success" : undefined}>
-      <td
-        className={cx("text-center", { "border-0": isLast })}
-        style={{ verticalAlign: "middle", width: "1px" }}
-      >
+    <tr className={cx({ "table-success": tab.active, "fst-italic": isOverdue })}>
+      <td className={cx("text-center")} style={{ verticalAlign: "middle", width: "1px" }}>
         <button
           className={cx("btn btn-xs btn-outline-secondary rounded-circle", {
             active: tabLockStatus.locked,
@@ -59,10 +73,7 @@ export default function OpenTabRow({
           {tabLockStatus.locked ? <i className="fas fa-lock" /> : <i className="fas fa-unlock" />}
         </button>
       </td>
-      <td
-        className={cx("text-center", { "border-0": isLast })}
-        style={{ verticalAlign: "middle", width: "32px" }}
-      >
+      <td className="text-center" style={{ verticalAlign: "middle", width: "32px" }}>
         <TabFavicon
           alt=""
           height={16}
@@ -72,12 +83,9 @@ export default function OpenTabRow({
           width={16}
         />
       </td>
-      <td
-        className={cx({ "border-0": isLast })}
-        style={{ paddingBottom: "4px", paddingTop: "4px", width: "75%" }}
-      >
+      <td style={{ paddingBottom: "4px", paddingTop: "4px", width: "100%" }}>
         <div
-          className="d-flex"
+          className={cx("d-flex", { "text-muted": isOverdue && !tab.active })}
           role="button"
           style={{ lineHeight: "1.3" }}
           tabIndex={0}
@@ -90,30 +98,62 @@ export default function OpenTabRow({
           </div>
         </div>
       </td>
-      <TabLockStatus
-        isLast={isLast}
-        tabLockStatus={tabLockStatus}
-        tabTime={tabTime}
-        windowLocked={windowLocked}
-      />
+      <td
+        style={{
+          position: "relative",
+          verticalAlign: "middle",
+          whiteSpace: "nowrap",
+          width: "1px",
+        }}
+      >
+        {windowHasGroups && (
+          <div
+            className="OpenTabRow-group-border"
+            style={
+              groupColor == null
+                ? undefined
+                : {
+                    backgroundColor: groupColor,
+                  }
+            }
+          />
+        )}
+        <div className="d-flex align-items-center justify-content-end gap-2 pe-2">
+          <TabLockContent
+            isTabActive={tab.active}
+            tabLockStatus={tabLockStatus}
+            timeRemaining={timeRemaining}
+            windowLocked={windowLocked}
+          />
+          {isFirstInGroup && (
+            <div
+              className="OpenTabRow-group-indicator"
+              style={{
+                backgroundColor: groupColor,
+              }}
+              title={tabGroup?.title}
+            />
+          )}
+        </div>
+      </td>
     </tr>
   );
 }
 
-function TabLockStatus({
-  isLast,
+function TabLockContent({
+  isTabActive,
   tabLockStatus,
-  tabTime,
+  timeRemaining,
   windowLocked,
 }: {
-  isLast: boolean;
+  isTabActive: boolean;
   tabLockStatus: TabLockStatus;
-  tabTime: number;
+  timeRemaining: number;
   windowLocked: boolean;
 }) {
   const { data: syncPersistData } = useStorageSyncPersistQuery();
-  const now = useContext(UseNowContext);
   const paused = syncPersistData?.paused;
+
   if (tabLockStatus.locked) {
     let reason: React.ReactNode;
     switch (tabLockStatus.reason) {
@@ -152,35 +192,23 @@ function TabLockStatus({
         tabLockStatus satisfies never;
     }
 
-    return (
-      <td
-        className={cx("text-center muted", { "border-0": isLast })}
-        style={{ verticalAlign: "middle" }}
-      >
-        {reason}
-      </td>
-    );
+    return <span className={isTabActive ? undefined : "text-muted"}>{reason}</span>;
   } else {
     let timeLeftContent;
     if (windowLocked) {
       timeLeftContent = chrome.i18n.getMessage("tabLock_lockedReason_window");
     } else if (paused) {
       timeLeftContent = chrome.i18n.getMessage("tabLock_lockedReason_paused");
+    } else if (timeRemaining <= 0) {
+      // `timeLeft` went negative — the countdown continued and is waiting for the interval to close
+      // this tab. It's also possible `minTabs` stopped the countdown and this will stay overdue
+      // until another tab is opened to jump-start it again.
+      timeLeftContent = <time style={isTabActive ? undefined : { opacity: 0.4 }}>⋯</time>;
     } else {
-      const cutOff = now - settings.stayOpen();
-      const timeLeft = -1 * Math.round((cutOff - tabTime) / 1000);
-      // If `timeLeft` is less than 0, the countdown likely continued and is waiting for the
-      // interval to clean up this tab. It's also possible the number of tabs is not below
-      // `minTabs`, which has stopped the countdown and locked this at a negative `timeLeft` until
-      // another tab is opened to jump start the countdown again.
-      timeLeftContent = timeLeft < 0 ? "…" : <time>{formatSecondsToDhms(timeLeft)}</time>;
+      timeLeftContent = <time>{formatSecondsToDhms(timeRemaining)}</time>;
     }
 
-    return (
-      <td className={cx("text-center", { "border-0": isLast })} style={{ verticalAlign: "middle" }}>
-        {timeLeftContent}
-      </td>
-    );
+    return <span>{timeLeftContent}</span>;
   }
 }
 

--- a/app/js/LockTab/useTabGroupsQuery.ts
+++ b/app/js/LockTab/useTabGroupsQuery.ts
@@ -1,0 +1,33 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+const TAB_GROUPS_QUERY_KEY = ["tabGroupsQuery"] as const;
+
+export default function useTabGroupsQuery() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!chrome.tabGroups) return () => {};
+    function invalidateTabGroupsQuery() {
+      queryClient.invalidateQueries({ queryKey: TAB_GROUPS_QUERY_KEY });
+    }
+    chrome.tabGroups.onCreated.addListener(invalidateTabGroupsQuery);
+    chrome.tabGroups.onMoved.addListener(invalidateTabGroupsQuery);
+    chrome.tabGroups.onRemoved.addListener(invalidateTabGroupsQuery);
+    chrome.tabGroups.onUpdated.addListener(invalidateTabGroupsQuery);
+    return () => {
+      chrome.tabGroups.onCreated.removeListener(invalidateTabGroupsQuery);
+      chrome.tabGroups.onMoved.removeListener(invalidateTabGroupsQuery);
+      chrome.tabGroups.onRemoved.removeListener(invalidateTabGroupsQuery);
+      chrome.tabGroups.onUpdated.removeListener(invalidateTabGroupsQuery);
+    };
+  }, [queryClient]);
+
+  return useQuery({
+    queryFn: () => {
+      if (!chrome.tabGroups) return [];
+      return chrome.tabGroups.query({});
+    },
+    queryKey: TAB_GROUPS_QUERY_KEY,
+  });
+}

--- a/app/js/LockTab/useTabsQuery.ts
+++ b/app/js/LockTab/useTabsQuery.ts
@@ -1,0 +1,31 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+const TABS_QUERY_KEY = ["tabsQuery"] as const;
+
+export default function useTabsQuery() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    function invalidateTabsQuery() {
+      queryClient.invalidateQueries({ queryKey: TABS_QUERY_KEY });
+    }
+    chrome.tabs.onActivated.addListener(invalidateTabsQuery);
+    chrome.tabs.onCreated.addListener(invalidateTabsQuery);
+    chrome.tabs.onMoved.addListener(invalidateTabsQuery);
+    chrome.tabs.onRemoved.addListener(invalidateTabsQuery);
+    chrome.tabs.onUpdated.addListener(invalidateTabsQuery);
+    return () => {
+      chrome.tabs.onActivated.removeListener(invalidateTabsQuery);
+      chrome.tabs.onCreated.removeListener(invalidateTabsQuery);
+      chrome.tabs.onMoved.removeListener(invalidateTabsQuery);
+      chrome.tabs.onRemoved.removeListener(invalidateTabsQuery);
+      chrome.tabs.onUpdated.removeListener(invalidateTabsQuery);
+    };
+  }, [queryClient]);
+
+  return useQuery({
+    queryFn: () => chrome.tabs.query({}),
+    queryKey: TABS_QUERY_KEY,
+  });
+}

--- a/app/manifest.template.json
+++ b/app/manifest.template.json
@@ -31,6 +31,7 @@
     "contextMenus",
     "sessions",
     "storage",
+    "tabGroups",
     "tabs"
   ]
 }


### PR DESCRIPTION
The first tab in a tab group gets a rounded square the same as both
Chrome and Firefox use. The tab colors closely match what I see on
my computer, but they may not exactly match all users' computers because
they have enum values like "orange" but no exact color value.

* This necessarily adds the [`tabGroups` permission][0] to Tab Wrangler
  in order to read info about tabGroups
* OpenTabRows get some cosmetic improvements: italic and muted text
  when the tab is ready to be closed (its timer is <=0)

Example dark mode:
<img width="714" height="468" alt="Screenshot 2026-04-09 at 10 44 38 PM" src="https://github.com/user-attachments/assets/3e0073a4-1536-42e8-aa3d-b3ff75cc0b20" />

Example light mode:
<img width="705" height="523" alt="Screenshot 2026-04-10 at 4 01 00 PM" src="https://github.com/user-attachments/assets/e2737736-1c96-4a19-908b-c31876506408" />

Closes https://github.com/tabwrangler/tabwrangler/issues/505

[0]: https://developer.chrome.com/docs/extensions/reference/api/tabGroups