### PR TITLE
Expose command for lock/unlock current window

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -17,11 +17,15 @@
   },
   "commandLockUnlockActiveTab": {
     "description": "Description of keyboard shortcut to lock or unlock the active tab",
-    "message": "Lock/Unlock the active tab"
+    "message": "Lock/Unlock active tab"
+  },
+  "commandLockUnlockCurrentWindow": {
+    "description": "Description of keyboard shortcut to lock or unlock the current window",
+    "message": "Lock/Unlock current window"
   },
   "commandWrangleCurrentTab": {
     "description": "Description of keyboard shortcut to close and save the active tab",
-    "message": "Close and save the active tab"
+    "message": "Close and save active tab"
   },
   "commandWrangleOpenPopup": {
     "description": "Description of keyboard shortcut to open TabWrangler popup",

--- a/app/background.ts
+++ b/app/background.ts
@@ -157,19 +157,25 @@ chrome.windows.onRemoved.addListener((windowId: number) => {
   settings.unlockWindow(windowId);
 });
 
-chrome.commands.onCommand.addListener((command) => {
+chrome.commands.onCommand.addListener(async (command) => {
   switch (command) {
     case "lock-unlock-active-tab":
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         settings.toggleTabs(tabs);
       });
       break;
-    case "wrangle-current-tab":
+    case "lock-unlock-current-window": {
+      const currentWindow = await chrome.windows.getCurrent();
+      if (currentWindow.id != null) settings.toggleWindow(currentWindow.id);
+      break;
+    }
+    case "wrangle-active-tab":
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         wrangleTabsAndPersist(tabs);
       });
       break;
     default:
+      console.warn(`[onCommand]: Received unhandled command "${command}"`);
       break;
   }
 });

--- a/app/js/settings.ts
+++ b/app/js/settings.ts
@@ -218,6 +218,12 @@ const Settings = {
     return this.set("lockedWindowIds", nextLockedWindowIds);
   },
 
+  toggleWindow(windowId: number): Promise<void> {
+    const lockedWindowIds = this.get("lockedWindowIds");
+    const index = lockedWindowIds.indexOf(windowId);
+    return index === -1 ? this.lockWindow(windowId) : this.unlockWindow(windowId);
+  },
+
   unlockWindow(windowId: number): Promise<void> {
     const lockedWindowIds = this.get("lockedWindowIds");
     const index = lockedWindowIds.indexOf(windowId);

--- a/app/manifest.template.json
+++ b/app/manifest.template.json
@@ -17,7 +17,10 @@
     "lock-unlock-active-tab": {
       "description": "__MSG_commandLockUnlockActiveTab__"
     },
-    "wrangle-current-tab": {
+    "lock-unlock-current-window": {
+      "description": "__MSG_commandLockUnlockCurrentWindow__"
+    },
+    "wrangle-active-tab": {
       "description": "__MSG_commandWrangleCurrentTab__"
     }
   },


### PR DESCRIPTION
This command is exposed along with others in the keyboard shortcut config area of the browser (both in Chrome and in Firefox).

Closes https://github.com/tabwrangler/tabwrangler/issues/575