### PR TITLE
Disable autocomplete in the search bar so that arrow keys don't select it

### DIFF
--- a/app/js/CorralTab/CorralTab.tsx
+++ b/app/js/CorralTab/CorralTab.tsx
@@ -453,6 +453,7 @@ export default function CorralTab() {
         >
           <div className="form-group mb-0">
             <input
+              autoComplete="off"
               className="form-control"
               name="search"
               onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
@@ -466,7 +467,6 @@ export default function CorralTab() {
               }}
               type="search"
               value={filter}
-              autocomplete="off"
             />
           </div>
         </form>

--- a/app/js/CorralTab/CorralTab.tsx
+++ b/app/js/CorralTab/CorralTab.tsx
@@ -466,6 +466,7 @@ export default function CorralTab() {
               }}
               type="search"
               value={filter}
+              autocomplete="off"
             />
           </div>
         </form>


### PR DESCRIPTION
Autocomplete shows in Firefox 152 (Developer Edition) in Arch Linux.