### PR TITLE
Add shortcuts for "wrangle to right" + "wrangle others"

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -25,7 +25,15 @@
   },
   "commandWrangleCurrentTab": {
     "description": "Description of keyboard shortcut to close and save the active tab",
-    "message": "Close and save active tab"
+    "message": "Wrangle active tab"
+  },
+  "commandWrangleTabsToRight": {
+    "description": "Description of keyboard shortcut to close and save all tabs to the right of the active tab",
+    "message": "Wrangle tabs to the right"
+  },
+  "commandWrangleOtherTabs": {
+    "description": "Description of keyboard shortcut to close and save all tabs except the active tab",
+    "message": "Wrangle other tabs"
   },
   "commandWrangleOpenPopup": {
     "description": "Description of keyboard shortcut to open TabWrangler popup",
@@ -33,7 +41,7 @@
   },
   "contextMenu_corralTab": {
     "description": "Label for context menu item that closes the clicked tab and adds it to the corral",
-    "message": "Close tab and save URL immediately"
+    "message": "Wrangle this tab"
   },
   "contextMenu_lockDomain": {
     "description": "Label for context menu item that locks the domain of the clicked tab",

--- a/app/background.ts
+++ b/app/background.ts
@@ -10,9 +10,15 @@ import {
   updateClosedCount,
   updateLastAccessed,
   wrangleTabs,
-  wrangleTabsAndPersist,
 } from "./js/tabUtil";
 import { getStorageLocalPersist, getStorageSyncPersist } from "./js/queries";
+import {
+  lockUnlockActiveTab,
+  lockUnlockCurrentWindow,
+  wrangleActiveTab,
+  wrangleOtherTabs,
+  wrangleTabsToRight,
+} from "./js/commands";
 import { CHECK_TO_CLOSE_INTERVAL_MS } from "./js/constants";
 import Menus from "./js/menus";
 import { debounce } from "lodash-es";
@@ -110,19 +116,19 @@ chrome.tabs.onActivated.addListener(async function onActivated(tabInfo) {
 });
 
 chrome.tabs.onCreated.addListener((tab: chrome.tabs.Tab) => {
-  // During startup, accumulate restored tabs. The first event switches from the 5s first-event
-  // timeout to a 1s debounce; each subsequent event resets that debounce. Once 1s passes without a
-  // new onCreated event, tabsRestoredPromise resolves with the full list.
   if (!startupComplete) {
+    // During startup, accumulate restored tabs. The first event switches from the 5s first-event
+    // timeout to a 1s debounce; each subsequent event resets that debounce. Once 1s passes without a
+    // new onCreated event, tabsRestoredPromise resolves with the full list.
     restoredTabs.push(tab);
     if (tabsRestoredTimeout != null) clearTimeout(tabsRestoredTimeout);
     tabsRestoredTimeout = setTimeout(
       () => resolveTabsRestored(restoredTabs),
       TABS_RESTORED_DEBOUNCE_MS,
     );
-    return;
+  } else {
+    onNewTab(tab);
   }
-  onNewTab(tab);
 });
 
 chrome.tabs.onRemoved.addListener(removeTab);
@@ -160,19 +166,19 @@ chrome.windows.onRemoved.addListener((windowId: number) => {
 chrome.commands.onCommand.addListener(async (command) => {
   switch (command) {
     case "lock-unlock-active-tab":
-      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        settings.toggleTabs(tabs);
-      });
+      await lockUnlockActiveTab();
       break;
-    case "lock-unlock-current-window": {
-      const currentWindow = await chrome.windows.getCurrent();
-      if (currentWindow.id != null) settings.toggleWindow(currentWindow.id);
+    case "lock-unlock-current-window":
+      await lockUnlockCurrentWindow();
       break;
-    }
     case "wrangle-active-tab":
-      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        wrangleTabsAndPersist(tabs);
-      });
+      await wrangleActiveTab();
+      break;
+    case "wrangle-other-tabs":
+      await wrangleOtherTabs();
+      break;
+    case "wrangle-tabs-to-right":
+      await wrangleTabsToRight();
       break;
     default:
       console.warn(`[onCommand]: Received unhandled command "${command}"`);

--- a/app/js/api/useWindowsGetLastFocused.ts
+++ b/app/js/api/useWindowsGetLastFocused.ts
@@ -8,6 +8,7 @@ const WINDOWS_LAST_FOCUSED_QUERY_KEY = ["windowsLastFocusedQuery"] as const;
  */
 export default function useWindowsGetLastFocused() {
   const queryClient = useQueryClient();
+
   useEffect(() => {
     function invalidateQuery() {
       queryClient.invalidateQueries({ queryKey: WINDOWS_LAST_FOCUSED_QUERY_KEY });
@@ -17,6 +18,7 @@ export default function useWindowsGetLastFocused() {
       chrome.windows.onFocusChanged.removeListener(invalidateQuery);
     };
   }, [queryClient]);
+
   return useQuery({
     queryFn: () => chrome.windows.getLastFocused(),
     queryKey: WINDOWS_LAST_FOCUSED_QUERY_KEY,

--- a/app/js/commands.ts
+++ b/app/js/commands.ts
@@ -1,0 +1,37 @@
+import settings from "./settings";
+import { wrangleTabsAndPersist } from "./tabUtil";
+
+export async function lockUnlockActiveTab(): Promise<void> {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  settings.toggleTabs(tabs);
+}
+
+export async function lockUnlockCurrentWindow(): Promise<void> {
+  const currentWindow = await chrome.windows.getCurrent();
+  if (currentWindow.id == null) return;
+
+  settings.toggleWindow(currentWindow.id);
+}
+
+export async function wrangleActiveTab(): Promise<void> {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  await wrangleTabsAndPersist(tabs);
+}
+
+export async function wrangleOtherTabs(): Promise<void> {
+  const tabs = await chrome.tabs.query({ currentWindow: true });
+  const activeTab = tabs.find((tab) => tab.active);
+  if (activeTab?.id == null) return;
+
+  const tabsToWrangle = tabs.filter((t) => t.id !== activeTab.id);
+  await wrangleTabsAndPersist(tabsToWrangle);
+}
+
+export async function wrangleTabsToRight(): Promise<void> {
+  const tabs = await chrome.tabs.query({ currentWindow: true });
+  const activeTab = tabs.find((tab) => tab.active);
+  if (activeTab?.id == null) return;
+
+  const tabsToWrangle = tabs.filter((t) => t.index > activeTab.index);
+  await wrangleTabsAndPersist(tabsToWrangle);
+}

--- a/app/manifest.template.json
+++ b/app/manifest.template.json
@@ -22,6 +22,12 @@
     },
     "wrangle-active-tab": {
       "description": "__MSG_commandWrangleCurrentTab__"
+    },
+    "wrangle-other-tabs": {
+      "description": "__MSG_commandWrangleOtherTabs__"
+    },
+    "wrangle-tabs-to-right": {
+      "description": "__MSG_commandWrangleTabsToRight__"
     }
   },
   "minimum_chrome_version": "110",


### PR DESCRIPTION
Enable configuring shortcuts for "Wrangle tabs to the right" and "Wrangle other tabs" similar to IDEs and text editors since these shortcuts are not exposed by browsers.

Closes https://github.com/tabwrangler/tabwrangler/issues/590